### PR TITLE
Update util.cpp

### DIFF
--- a/synthts_et/lib/label/util.cpp
+++ b/synthts_et/lib/label/util.cpp
@@ -511,7 +511,7 @@ CFSWString replace_schar (CFSWString c) {
     if (c == L"$") return L"dollarit";
     if (c == L"£") return L"naela";
     if (c == L"%") return L"protsenti";
-    if (c == L"&") return L"änd";
+    if (c == L"&") return L"ja";
     if (c == L"/") return L"kaldkriips";
     if (c == L"\\") return L"tagurpidi kaldkriips";    
     if (c == L"=") return L"võrdub";


### PR DESCRIPTION
"&" lauses peaks vast lugema siiski eesti keeles kui "ja"

http://ekspress.delfi.ee/teateid_elust/guud-ja-baad-nadala-sona?id=74206865
"Guud ja bääd & Nädala sõna"
-> 
"Guud ja bääd ja Nädala sõna"
